### PR TITLE
Vberenz/fk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ set(all_target_exports)
 ###########
 
 add_library( ${PROJECT_NAME} SHARED
-  src/actuator_state.cpp)
+  src/actuator_state.cpp
+  src/robot_fk_extended_state.cpp)
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/include/o80_pam/pressure_state.hpp
+++ b/include/o80_pam/pressure_state.hpp
@@ -42,4 +42,4 @@ namespace o80_pam:
         friend shared_memory::private_serialization;
         int pressure_;
     }
-}  // namespace o80_pam:
+}  // namespace :

--- a/include/o80_pam/robot_fk_extended_state.hpp
+++ b/include/o80_pam/robot_fk_extended_state.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Max Planck Gesellschaft
+// Author : Vincent Berenz
+
+#pragma once
+
+#include <array>
+#include "shared_memory/serializer.hpp"
+
+namespace o80_pam
+{
+/* ! RobotFKExtendedState encapsulates the forward kinematics of the robot
+ *   (position, velocity and orientation of the racket).
+ *   It is meant to be used as ExtendedState in a o80 observation
+ *   (i.e. supplementary data that can be added to an observation).
+ *   See pam_mujoco/mirror_robot.hpp for an example of the FK data of the
+ *   simulated robot is added to an (o80) observation
+ */
+
+class RobotFKExtendedState
+{
+public:
+    RobotFKExtendedState();
+    RobotFKExtendedState(const std::array<double, 3>& position,
+                         const std::array<double, 9>& orientation);
+    void set_position(int dim, double value);
+    void set_orientation(int dim, double value);
+    const std::array<double, 3>& get_position();
+    const std::array<double, 9>& get_orientation();
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(position_, orientation_);
+    }
+
+private:
+    friend shared_memory::private_serialization;
+    std::array<double, 3> position_;
+    std::array<double, 9> orientation_;
+};
+
+}  // namespace o80_pam

--- a/src/robot_fk_extended_state.cpp
+++ b/src/robot_fk_extended_state.cpp
@@ -1,0 +1,36 @@
+#include "o80_pam/robot_fk_extended_state.hpp"
+
+namespace o80_pam
+{
+RobotFKExtendedState::RobotFKExtendedState()
+{
+}
+
+RobotFKExtendedState::RobotFKExtendedState(
+    const std::array<double, 3>& position,
+    const std::array<double, 9>& orientation)
+    : position_{position}, orientation_{orientation}
+{
+}
+
+const std::array<double, 3>& RobotFKExtendedState::get_position()
+{
+    return position_;
+}
+
+const std::array<double, 9>& RobotFKExtendedState::get_orientation()
+{
+    return orientation_;
+}
+
+void RobotFKExtendedState::set_position(int dim, double value)
+{
+    position_[dim] = value;
+}
+
+void RobotFKExtendedState::set_orientation(int dim, double value)
+{
+    orientation_[dim] = value;
+}
+
+}  // namespace o80_pam

--- a/srcpy/wrappers.cpp
+++ b/srcpy/wrappers.cpp
@@ -643,10 +643,10 @@ void add_mirror_robot_observation_and_serializer(pybind11::module& m)
 // (with extra functions compared to the native o80 wrappers)
 void add_mirror_robot_frontend(pybind11::module& m)
 {
-    typedef o80::Observation<NB_DOFS, o80::State2d, o80::VoidExtendedState>
+    typedef o80::Observation<NB_DOFS, o80::State2d, o80_pam::RobotFKExtendedState>
         observation;
     typedef o80::
-        FrontEnd<QUEUE_SIZE, NB_DOFS, o80::State2d, o80::VoidExtendedState>
+      FrontEnd<QUEUE_SIZE, NB_DOFS, o80::State2d, o80_pam::RobotFKExtendedState>
             frontend;
     pybind11::class_<frontend>(m, "MirrorRobotFrontEnd")
         // generic frontend bindings (similar to what o80::pybind11_helper.hpp


### PR DESCRIPTION
# Issue

In pam_robot, we need to export via o80 the cartesian state of the simulated robot

# Solution

Added a serializable class RobotFKExtendedState that pam_robot can use as o80 extended state

# Note

Because I applied the formatting executable, this pull request comes with a lot of noise. Only robot_fk_extended_class.hpp and robot_fk_extended_class.cpp are of interest.